### PR TITLE
Correct `execute` command name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ This client allows you to submit free-form change events to the FireHydrant API 
 ### Actions
 
 * `event` Submits a change event to the FH API
-* `exec` Executes a command and submits a corresponding change event to the FH API
+* `execute` Executes a command and submits a corresponding change event to the FH API
 * `init` Configures the client for subsequent invocations
 
 ### Parameters
@@ -48,7 +48,7 @@ The following examples assume that `FH_API_KEY` is set in your environment.
 
     fhcli event --environment "production" "hourly reconciliation task" 
     fhcli event --environment "staging" --identities git=git@github.com/firehydrant/myrepo:a0b0c0d0 "CI build succeeded"
-    fhcli exec --environment "staging" --identities revision=a0a0a0 -- docker build .
+    fhcli execute --environment "staging" --identities revision=a0a0a0 -- docker build .
 
 To configure firehydrant and write a config file (defaults to /tmp/firehydrant.cfg) for subsequent invocations of the tool:
 


### PR DESCRIPTION
The command name is `execute`, at least as of the most recent CLI version:

```
./fhcli 
NAME:
   fhcli - A new cli application

USAGE:
   fhcli [global options] command [command options] [arguments...]

VERSION:
   0.0.13 (4fb6cfc4823fbce9a9697595445f969e7bac539a)

COMMANDS:
     init     write a config file to be used in future invocations of the FireHydrant CLI
     event    submit an event to the FireHydrant API
     execute  execute a command and submit metrics to the FireHydrant API
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --apiKey value   firehydrant.io API Key [$FH_API_KEY]
   --apiHost value  firehydrant.io API hostname (default: "api.firehydrant.io") [$FH_API_HOST]
   --debug          Enable debug output for API calls
   --ignoreErrors   exit 0 on errors from FH API (default)
   --config value   config file [$FH_CONFIG_FILE]
   --help, -h       show help
   --version, -v    print the version```